### PR TITLE
개발 환경 설명 수정

### DIFF
--- a/README.EN.md
+++ b/README.EN.md
@@ -19,7 +19,7 @@ Installation and usage guide are introduced in [Tablecloth Introduction Page(KO)
 
 ## Build Environment
 
-* Visual Studio 2019 or up to
+* Visual Studio 2022 or up to
 * .NET 6.0 SDK
 * .NET Framework 4.8 SDK
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## 빌드 환경
 
-* Visual Studio 2019 이상
+* Visual Studio 2022 이상
 * .NET 6.0 SDK
 * .NET Framework 4.8 SDK
 


### PR DESCRIPTION
Windows용 Visual Studio 2019는 .NET 6.0을 지원하지 않음. https://learn.microsoft.com/en-us/answers/questions/620284/how-to-target-net-60-with-visual-studio-2019.html