### PR TITLE
WindowsSandbox.exe 프로세스 호출 방법 변경

### DIFF
--- a/src/TableCloth/Implementations/SandboxLauncher.cs
+++ b/src/TableCloth/Implementations/SandboxLauncher.cs
@@ -74,21 +74,15 @@ namespace TableCloth.Implementations
 
         public void RunSandbox(IAppUserInterface appUserInteface, string sandboxOutputDirectory, string wsbFilePath)
         {
-            var wsbExecPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.System),
-                "WindowsSandbox.exe");
-
             if (!ValidateSandboxSpecFile(wsbFilePath, out string reason))
             {
                 _appMessageBox.DisplayError(null, reason, true);
                 return;
             }
 
-            var process = new Process()
-            {
-                EnableRaisingEvents = true,
-                StartInfo = new ProcessStartInfo(wsbExecPath, wsbFilePath) { UseShellExecute = false, },
-            };
+            var process = new Process();
+            process.StartInfo.FileName = "cmd";
+            process.StartInfo.Arguments = "/c start \"\" \"" + wsbFilePath + "\"";
 
             if (!process.Start())
             {


### PR DESCRIPTION
#76 에 대해 동일한 문제를 겪고 있었습니다.

어떠한 이유인지 알 수 없지만 WindowsSandbox.exe 를 다이렉트로 호출하면 wsb 파일에 문제가 없음에도 잘못된 파일 형식이라고 오류가 발생했습니다. (생성된 wsb 파일을 탐색기에서 실행하였을 때 정상 작동 확인함)
프로세스 호출 방법을 cmd 를 통해 시작하도록 변경하니 정상적으로 동작하고 있습니다.