### PR TITLE
카탈로그 항목별 ToolTip 추가 + GitHub Action 문제점 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-        token: ${{ secrets.TABLECLOTH_GITHUB_PAT }}
+        #token: ${{ secrets.TABLECLOTH_GITHUB_PAT }}
 
     # Install the .NET Core workload
     - name: Install .NET Core

--- a/.github/workflows/publish-msi.yml
+++ b/.github/workflows/publish-msi.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-        token: ${{ secrets.TABLECLOTH_GITHUB_PAT }}
+        #token: ${{ secrets.TABLECLOTH_GITHUB_PAT }}
 
     # Install the .NET Core workload
     - name: Install .NET Core

--- a/src/TableCloth/Pages/CatalogPage.xaml
+++ b/src/TableCloth/Pages/CatalogPage.xaml
@@ -216,6 +216,9 @@
                         </Grid.RowDefinitions>
                         <Image Grid.Row="0" x:Name="Icon" Source="{Binding Id, Mode=OneWay, Converter={StaticResource ServiceLogoConverter}}" RenderOptions.BitmapScalingMode="Fant" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="Uniform" />
                         <TextBlock Grid.Row="2" Text="{Binding DisplayName}" TextAlignment="Center" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" />
+                        <Grid.ToolTip>
+                            <TextBlock Text="{Binding DisplayName}" TextWrapping="NoWrap" TextTrimming="None"/>
+                        </Grid.ToolTip>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>


### PR DESCRIPTION
항목 이름이 너무 길어, 바로 확인하기 어려운 점을 개선하고자 함.

(추가: GitHub Action에서 PAT Token을 굳이 따로 지정할 의미가 없어서, 관련 parameter input을 비활성화함.) 