### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/winget_publish.yml
+++ b/.github/workflows/winget_publish.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   winget:
     name: Publish winget package


### PR DESCRIPTION
Potential fix for [https://github.com/yourtablecloth/TableCloth/security/code-scanning/5](https://github.com/yourtablecloth/TableCloth/security/code-scanning/5)

In general, the fix is to explicitly declare GITHUB_TOKEN permissions for this workflow, restricting them to the minimum needed. This workflow only needs to read release metadata from the current repository (done via `curl` to the public GitHub API) and does not modify anything in the repo using `GITHUB_TOKEN`. Therefore, `contents: read` is sufficient and conservative. We can set this at the workflow root so it applies to all jobs in the file.

The best single fix is to add a `permissions` block near the top-level of `.github/workflows/winget_publish.yml`, between the `on:` section and the `jobs:` section. This will ensure that, by default, `GITHUB_TOKEN` has only read access to repository contents for all jobs in this workflow. No other permissions (such as `pull-requests`, `issues`, or `packages`) are required by the shown steps. No imports or additional methods are needed because this is a YAML configuration change only.

Concretely:
- Edit `.github/workflows/winget_publish.yml`.
- After the existing `on:` block (lines 3–6), insert:

```yaml
permissions:
  contents: read
```

- Leave the rest of the file unchanged, as it already uses a PAT (`GITHUB_PAT`) for the write operation to winget-pkgs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
